### PR TITLE
Change `className` (React) to `class` (Svelte)

### DIFF
--- a/imports/ui/App.svelte
+++ b/imports/ui/App.svelte
@@ -39,7 +39,7 @@
 <div class="container">
   <header>
     <h1>Todo List ({ $incompleteCount })</h1>
-    <label className="hide-completed">
+    <label class="hide-completed">
       <input
         type="checkbox"
         bind:checked={hideCompleted}


### PR DESCRIPTION
Fixes a small typo from somebody presumably used to React's way of doing things. :) Replaces React's `className` attribute  with HTML/Svelte's default `class` attribute.